### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/1](https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow. This can be done at the top level (applies to all jobs) or at the job level. Unless there’s a reason to scope permissions differently per job, it is best to set this at the workflow level for clarity and enforcement. In this workflow, only read access to repository contents is needed for actions like checkout and running tests, so setting `permissions: contents: read` at the top level is the least-privilege configuration and aligns with best practices. This change should be inserted directly under the `name` field (line 4) and above the `on` trigger (line 6) in `.github/workflows/go.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
