### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -11,6 +11,8 @@
 # For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
 
 name: SLSA generic generator
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/5](https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/5)

The best fix is to add a `permissions:` block with the least privilege required at the highest practical level. Since only the `provenance` job needs elevated permissions (and is already explicitly scoped), the rest of the workflow (and particularly the `build` job) should default to minimal permissions, which is typically `contents: read`. This can be accomplished by adding `permissions: contents: read` at the root of the workflow (directly under the `name` and before or after `on:`), ensuring that any jobs not specifying permissions (like `build`) will use the restricted `contents: read` only. This change is simple, backwards compatible, and scoped to the affected file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
