### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -13,6 +13,9 @@
 
 name: Run Datadog Synthetic tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/4](https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/4)

To fix this issue, we should explicitly define a `permissions` block in the workflow. The safest and most general way is to declare this at the workflow root (the top level of the YAML file, before the `jobs:` key). Since the currently shown jobs only check out code and run CI steps with no evidence of needing to write to the repository, the minimal permission needed is `contents: read`, which allows checking out the code but nothing more. No changes are needed to imports or structure—just introduce the `permissions` key at the appropriate location in the YAML.

To summarize:
- Add a `permissions:` block at the root (after `name:`/`on:` and before `jobs:`) with `contents: read`.
- No other code changes or dependency updates required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
