### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/3](https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/3)

To fix the problem, add a `permissions` block at the root of the workflow file, specifying `contents: read`. This follows the principle of least privilege, as all steps in this workflow just check out the code, build, and test, none of which require read-write access to repository contents or any other permissions.  
Specifically, insert the following at the root of the workflow—ideally just below the `name` key, before `on`. No other code changes are required. No imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
