### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,6 +2,9 @@ name: Python Package using Conda
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/2](https://github.com/santiagourdaneta/Adaptive-Learning-Platform/security/code-scanning/2)

To fix the problem, an explicit `permissions` block should be added to the workflow to restrict what the GITHUB_TOKEN can access during workflow execution. According to the recommendations, this is best placed either at the top (workflow level, before `jobs:`) or at the job level (under each job). If all jobs can operate with minimal permissions, set it at the workflow root. In this workflow, the steps are for checking out code, installing Python and dependencies, linting, and running tests—all of which do not require write access to repository contents or issues. Thus, specifying `permissions: contents: read` near the top, after the workflow `name` and `on` block and before `jobs:`, is the optimal fix.

No external packages or code changes are required—just an edit to the YAML file structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
